### PR TITLE
Dont you use $BUILDPLATFORM arg in global scope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG GOLANG_IMAGE_TAG=1.19
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:${GOLANG_IMAGE_TAG} as build
+FROM mcr.microsoft.com/oss/go/microsoft/golang:${GOLANG_IMAGE_TAG} as build
 COPY GNUmakefile /src/GNUmakefile
 COPY scripts /src/scripts
 RUN cd /src && \
@@ -7,7 +7,7 @@ RUN cd /src && \
     apt install -y zip npm  && \
     make tools
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:${GOLANG_IMAGE_TAG} as runner
+FROM mcr.microsoft.com/oss/go/microsoft/golang:${GOLANG_IMAGE_TAG} as runner
 ARG TERRAFORM_VERSION=1.2.7
 ARG TFLINT_AZURERM_VERSION=0.17.1
 ARG TFLINT_BASIC_EXT_VERSION=0.0.2


### PR DESCRIPTION
If you do, it will pull the image for the platform matching the host (on GHA runner ubuntu-latest it's linux/amd64)

https://github.com/docker/build-push-action/issues/668